### PR TITLE
Fix version of numpy expected by networkx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp==3.7.4
 networkx==2.4
+numpy==1.20.1
 paho-mqtt==1.5.0
 rhasspy-hermes~=0.6.0
 rhasspy-nlu~=0.3.0


### PR DESCRIPTION
rhasspy-remote-http-hermes uses networkx==2.4 which uses numpy.int:
https://github.com/networkx/networkx/blob/networkx-2.4/networkx/readwrite/graphml.py#L346

This was deprecated in newer version of numpy. Instead of upgrading, which I am not qualified to do with my limited python experience, I am fixing the numpy version as what is expected throughout rhasspy to 1.20.1:
https://github.com/rhasspy/rhasspy/blob/0b6caab2ea41f022fa4d8c0714ad00befcbb38d2/Dockerfile#L150

I will do this in other submodules if this gets approved to make the instructions for virtual environment work:
https://rhasspy.readthedocs.io/en/latest/installation/#virtual-environment

There is a similar need to fix the markupsafe transitive dependency to version 2.0.1.